### PR TITLE
Run Python unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
-language: node_js
-node_js:
-  - "0.12"
+language: python
+
+python:
+  - 2.7
+
+# Use container-based infrastructure
+sudo: false
+
 env:
   - DISABLE_NOTIFIER=true
-before_script:
-  - npm install -g gulp
+
+install:
+  - npm install gulp --global
+  - npm install gulp --save-dev
+  - npm install
+
+  - pip install -r submission-form-scripts/requirements.txt
+
 script:
   - gulp clean
   - gulp styles
   - gulp scripts
+
+  # Python unit tests
+  - python submission-form-scripts/test_botsheeter.py


### PR DESCRIPTION
- Switch the build to a Python box.
- Still runs the gulp tests.
- Use container-based infrastructure: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Closes #49.
