### PR TITLE
Optimise with optipng and pngcrush

### DIFF
--- a/submission-form-scripts/botshotter.py
+++ b/submission-form-scripts/botshotter.py
@@ -17,7 +17,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 import StringIO
-import os.path
+import os
 import time
 
 
@@ -34,6 +34,17 @@ def do_one_account(driver, url_or_username, outdir, headless):
     im = take_shot(driver, url, headless)
     im = crop_image(im, headless, url_or_username)
     im.save(outfile)
+
+    # Optimise with optipng (if binary in path)
+    cmd = "optipng -force -o7 '{0}'".format(outfile)
+    print(cmd)
+    os.system(cmd)
+
+    # Optimise with pngcrush (if binary in path)
+    cmd = ("pngcrush -ow -rem gAMA -rem alla -rem cHRM -rem iCCP -rem sRGB "
+           "-rem time '{0}'").format(outfile)
+    print(cmd)
+    os.system(cmd)
 
 
 def get_url(url_or_username):
@@ -182,7 +193,8 @@ def botshotter(url, outdir, headless=False):
         urls = [url]
 
     for url in urls:
-        outdir = bot_directory(url)
+        if not outdir:
+            outdir = bot_directory(url)
         print('Creating thumbnail from ' + url + ', saving to ' + outdir +
               ' ...')
         do_one_account(driver, url, outdir, headless)


### PR DESCRIPTION
(Re: Fourth point in https://github.com/botwiki/botwiki.org/issues/40)

[Trimage uses](https://github.com/Kilian/Trimage/blob/master/src/trimage/trimage.py#L435) `optipng`, `advpng` and `pngcrush` with these options:

`u"optipng" + exe + " -force -o7 '%(file)s'&&advpng" + exe + " -z4 '%(file)s' && pngcrush -rem gAMA -rem alla -rem cHRM -rem iCCP -rem sRGB -rem time '%(file)s' '%(file)s.bak' && mv '%(file)s.bak' '%(file)s'"`

`optipng` and `pngcrush` are the easiest to install (at least on OS X, which I'm using right now: `brew install optipng pngcrush`) so this is how to use those with the same options.

If either or both aren't installed, the script should just continue as normal with no errors, as errors from the system call are ignored.

Some tests with GenerateACat:
- 451K original
- 445K just `pngcrush`
- 395K just `optipng`
- 395K `optipng` then `pngcrush`

So with this single test, `pngcrush` didn't make any difference when run after `optipng` (the byte count is the same too). But it may be useful in other cases.
