### PR TITLE
Init Colorama for Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
 
   # Python unit tests
   - python submission-form-scripts/test_botsheeter.py
+  # Error and style-checker
+  - flake8 submission-form-scripts/*.py

--- a/submission-form-scripts/botsheeter.py
+++ b/submission-form-scripts/botsheeter.py
@@ -15,20 +15,6 @@ from colorama import init, Fore, Style
 
 # from pprint import pprint
 
-init()  # Initialise Colorama for Windows
-print()
-print(Fore.BLUE)
-print("   ;")
-print('  ["]')
-print(" /[_]\ " + Style.RESET_ALL + "botwiki.org")
-print(Fore.BLUE + "  ] [")
-print(Style.RESET_ALL)
-print()
-
-print("Starting botsheeter.py, a Botwiki.org script by " + Fore.BLUE +
-      "twitter.com/hugovk" + Style.RESET_ALL + "...")
-
-
 def clean_path(path):
     return path.replace('..', '')
 
@@ -260,6 +246,19 @@ if __name__ == "__main__":
         '-x', '--test', action='store_true',
         help="Test mode: create local files but don't update the spreadsheet")
     args = parser.parse_args()
+
+    init()  # Initialise Colorama for Windows
+    print()
+    print(Fore.BLUE)
+    print("   ;")
+    print('  ["]')
+    print(" /[_]\ " + Style.RESET_ALL + "botwiki.org")
+    print(Fore.BLUE + "  ] [")
+    print(Style.RESET_ALL)
+    print()
+
+    print("Starting botsheeter.py, a Botwiki.org script by " + Fore.BLUE +
+          "twitter.com/hugovk" + Style.RESET_ALL + "...")
 
     json_key = json.load(open(args.json))
     scope = ['https://spreadsheets.google.com/feeds']

--- a/submission-form-scripts/botsheeter.py
+++ b/submission-form-scripts/botsheeter.py
@@ -15,6 +15,7 @@ from colorama import init, Fore, Style
 
 # from pprint import pprint
 
+
 def clean_path(path):
     return path.replace('..', '')
 

--- a/submission-form-scripts/botsheeter.py
+++ b/submission-form-scripts/botsheeter.py
@@ -11,7 +11,7 @@ import gspread  # pip install gspread
 import json
 import os
 from oauth2client.client import SignedJwtAssertionCredentials
-from colorama import init, Fore, Back, Style
+from colorama import init, Fore, Style
 
 # from pprint import pprint
 
@@ -25,10 +25,13 @@ print(Fore.BLUE + "  ] [")
 print(Style.RESET_ALL)
 print()
 
-print("Starting botsheeter.py, a Botwiki.org script by " + Fore.BLUE + "twitter.com/hugovk" + Style.RESET_ALL + "...")
+print("Starting botsheeter.py, a Botwiki.org script by " + Fore.BLUE +
+      "twitter.com/hugovk" + Style.RESET_ALL + "...")
+
 
 def clean_path(path):
     return path.replace('..', '')
+
 
 def make_twitter_url(text, force_it=False):
     """ Do the best to turn it into a Twitter URL """
@@ -287,13 +290,13 @@ if __name__ == "__main__":
 
         print("Processing " + bot['username'] + "...")
 
-        if ("twitter.com" in bot['location']) or ("tumblr.com" in bot['location']):
+        if "twitter.com" in bot['location'] or "tumblr.com" in bot['location']:
             bot_page_urls.append(bot['location'])
         else:
-            print(Fore.RED + "Unable to make screenshot for " + bot['username'] + ", please do it manually")
+            print(Fore.RED + "Unable to make screenshot for " +
+                  bot['username'] + ", please do it manually")
             print("ERROR: Unsuported network")
             print(Fore.RESET)
-
 
         bot['description'] = row[2]
         bot['tags'] = row[3]
@@ -312,12 +315,13 @@ if __name__ == "__main__":
         outfile = bot_md_filename(bot)
 
         if os.path.isfile(outfile):
-            print(Fore.RED + clean_path(outfile) + " already exists, skipping" + Style.RESET_ALL)
+            print(Fore.RED + clean_path(outfile) +
+                  " already exists, skipping" + Style.RESET_ALL)
             continue  # Don't overwrite existing
         else:
             created_bots.append(clean_path(outfile))
 
-        #print(bot)
+        # print(bot)
         md_file_text = format_md(bot)
         # print()
         # print(md_file_text)
@@ -334,11 +338,11 @@ if __name__ == "__main__":
             added_col = 12
             wks.update_cell(added_row, added_col, "true")
 
-    print(Fore.GREEN + "Finished processing, skipped " + str(len(skipped_bots)) + " bots:")
+    print(Fore.GREEN + "Finished processing, skipped " +
+          str(len(skipped_bots)) + " bots:")
     print(Fore.RESET + Style.DIM)
     print(', '.join(skipped_bots))
     print(Style.RESET_ALL)
-
 
     if bot_page_urls:
         # Prep botshotter.py call

--- a/submission-form-scripts/botsheeter.py
+++ b/submission-form-scripts/botsheeter.py
@@ -11,10 +11,11 @@ import gspread  # pip install gspread
 import json
 import os
 from oauth2client.client import SignedJwtAssertionCredentials
-from colorama import Fore, Back, Style
+from colorama import init, Fore, Back, Style
 
 # from pprint import pprint
 
+init()  # Initialise Colorama for Windows
 print()
 print(Fore.BLUE)
 print("   ;")

--- a/submission-form-scripts/botshotter.py
+++ b/submission-form-scripts/botshotter.py
@@ -172,12 +172,12 @@ def bot_directory(url):
         return "../content/bots/redditbots/images/"
     elif "tumblr.com" in url:
         return "../content/bots/tumblr-bots/images/"
-    elif network == 'Slack':
-        return "../content/bots/slackbots/images/"
-    elif network == 'Kik':
-        return "../content/bots/kik-bots/images/"
-    elif network == 'Snapchat':
-        return "../content/bots/snapchat-bots/images/"
+    # elif network == 'Slack':
+        # return "../content/bots/slackbots/images/"
+    # elif network == 'Kik':
+        # return "../content/bots/kik-bots/images/"
+    # elif network == 'Snapchat':
+        # return "../content/bots/snapchat-bots/images/"
     return None
 
 

--- a/submission-form-scripts/botshotter.py
+++ b/submission-form-scripts/botshotter.py
@@ -15,16 +15,15 @@ from PIL import Image  # pip install pillow
 from selenium import webdriver, common  # pip install selenium
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support import expected_conditions as ec
 import StringIO
 import os
 import time
-from colorama import Fore, Back, Style
+from colorama import Fore
 
 
 def clean_path(path):
     return path.replace('..', '')
-
 
 
 def do_one_account(driver, url_or_username, outdir, headless):
@@ -102,7 +101,7 @@ def take_shot(driver, url, headless):
     wait = WebDriverWait(driver, 10)
 
     if "twitter.com" in url:
-        wait.until(EC.visibility_of_element_located((
+        wait.until(ec.visibility_of_element_located((
             By.CSS_SELECTOR, 'img.ProfileAvatar-image')))
 
         # Remove some clutter
@@ -112,7 +111,8 @@ def take_shot(driver, url, headless):
         delete_element_by_class_name(driver, 'trends')
         delete_element_by_class_name(driver, 'user-actions-follow-button')
 #    elif "tumblr.com" in url:
-#        wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, 'img.ProfileAvatar-image')))
+#        wait.until(ec.visibility_of_element_located(
+#                   (By.CSS_SELECTOR, 'img.ProfileAvatar-image')))
 
     if not headless:
         if "twitter.com" in url:
@@ -203,8 +203,8 @@ def botshotter(url, outdir, headless=False):
     for url in urls:
         if not outdir:
             outdir = bot_directory(url)
-        print('Creating thumbnail from ' + url + ', saving to ' + clean_path(outdir) +
-              ' ...')
+        print('Creating thumbnail from ' + url + ', saving to ' +
+              clean_path(outdir) + ' ...')
         do_one_account(driver, url, outdir, headless)
 
     driver.quit()

--- a/submission-form-scripts/requirements.txt
+++ b/submission-form-scripts/requirements.txt
@@ -11,3 +11,4 @@ hypothesis
 
 # utilities
 colorama
+flake8


### PR DESCRIPTION
The colours weren't working on Windows:

```
←[34m
   ;
  ["]
 /[_]\ ←[0mbotwiki.org
←[34m  ] [
←[0m
```

Because Colorama wasn't being initialised. Calling `init()` fixes it for standard cmd.exe (but not Git BASH but I mainly use that just for git things).

---

Also some other things:
- flake8 style fixes
- Run flake8 on Travis CI so it can fail builds
- Comment out some code that has an undefined variable `network`
- Move the preamble inside the `_name__ == "__main__` block. This means the it only gets run when running the script directly (eg `python botsheeter.py`) and not when imported (eg `python test_botsheeter.py`)
