### PR TITLE
Fix bug when Twitter URL is http

### DIFF
--- a/submission-form-scripts/botsheeter.py
+++ b/submission-form-scripts/botsheeter.py
@@ -37,6 +37,9 @@ def clean_path(path):
 
 def make_twitter_url(text, force_it=False):
     """ Do the best to turn it into a Twitter URL """
+    if text.startswith("http://twitter.com"):
+        text = text.replace("http://twitter.com", "https://twitter.com")
+
     if text.startswith("twitter.com"):
         return "https://" + text.replace(" ", "")
     if text.startswith("https://twitter.com"):

--- a/submission-form-scripts/test_botsheeter.py
+++ b/submission-form-scripts/test_botsheeter.py
@@ -175,10 +175,15 @@ class TestIt(unittest.TestCase):
         bot = {}
         bot['tags'] = "twitter"
         bot['location'] = "https://twitter.com/botwikidotorg"
-#         bot['interactive'] = "Yes"
         tags = botsheeter.bot_tags(bot)
         self.assertEqual(
             tags, "twitter,twitterbot,inactive")
+
+    def test_make_twitter_url_http_twitter(self):
+        input = "http://twitter.com/botwikidotorg"
+        force_it = True
+        output = botsheeter.make_twitter_url(input, force_it)
+        self.assertEqual(output, "https://twitter.com/botwikidotorg")
 
 
 class TestWithHypothesis(unittest.TestCase):


### PR DESCRIPTION
Input like "http://twitter.com/swizzard" was being turned into "https://twitter.com/http://twitter.com/swizzard".

re: https://github.com/botwiki/botwiki.org/pull/67#discussion_r43048521
