### PR TITLE
Pin oauth2client version to 1.5.2

### DIFF
--- a/submission-form-scripts/requirements.txt
+++ b/submission-form-scripts/requirements.txt
@@ -1,6 +1,6 @@
 # botsheeter.py
 gspread
-oauth2client
+oauth2client==1.5.2
 
 # botshotter.py
 pillow>=2.9.0


### PR DESCRIPTION
Previously passing builds had started failing with:

```
$ python submission-form-scripts/test_botsheeter.py
Traceback (most recent call last):
  File "submission-form-scripts/test_botsheeter.py", line 14, in <module>
    import botsheeter
  File "/home/travis/build/botwiki/botwiki.org/submission-form-scripts/botsheeter.py", line 13, in <module>
    from oauth2client.client import SignedJwtAssertionCredentials
ImportError: cannot import name SignedJwtAssertionCredentials
```

The build had previously been using oauth2client 1.5.2 but now uses 2.0.0 which evidently has no SignedJwtAssertionCredentials. 

So let's pin the version to the working 1.5.2.
