### PR TITLE
Upgrade Python pip on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - npm install gulp --save-dev
   - npm install
 
-  - pip install "pip>=1.5.6"
+  - pip install -U "pip>=1.5.6"
   - pip install "pycrypto>=2.6"
   - pip install requests pyOpenSSL ndg-httpsclient pyasn1
   - pip install docutils


### PR DESCRIPTION
Using the latest pip means it can use the latest type of binaries (called "wheels") of Python dependencies instead of building some of them from source, which is quicker (16.15 -> 7.76s for one step).

Before, with pip 6.0.7 (16.15s):

```
16.15s$ pip install -r submission-form-scripts/requirements.txt
Collecting gspread (from -r submission-form-scripts/requirements.txt (line 2))
  Downloading gspread-0.4.1.tar.gz
Collecting oauth2client==1.5.2 (from -r submission-form-scripts/requirements.txt (line 3))
  Downloading oauth2client-1.5.2.tar.gz (56kB)
    100% |################################| 57kB 3.3MB/s 
Collecting pillow>=2.9.0 (from -r submission-form-scripts/requirements.txt (line 6))
  Downloading Pillow-3.4.1.zip (11.0MB)
    100% |################################| 11.0MB 53kB/s 
Collecting selenium (from -r submission-form-scripts/requirements.txt (line 7))
  Downloading selenium-2.53.6-py2.py3-none-any.whl (884kB)
    100% |################################| 884kB 685kB/s 
Collecting hypothesis (from -r submission-form-scripts/requirements.txt (line 10))
  Downloading hypothesis-3.5.3.tar.gz (73kB)
    100% |################################| 73kB 5.8MB/s 
Collecting colorama (from -r submission-form-scripts/requirements.txt (line 13))
  Downloading colorama-0.3.7-py2.py3-none-any.whl
Collecting flake8 (from -r submission-form-scripts/requirements.txt (line 14))
  Downloading flake8-3.0.4-py2.py3-none-any.whl (64kB)
    100% |################################| 65kB 6.3MB/s 
Requirement already satisfied (use --upgrade to upgrade): requests>=2.2.1 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from gspread->-r submission-form-scripts/requirements.txt (line 2))
Collecting httplib2>=0.9.1 (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
  Downloading httplib2-0.9.2.zip (210kB)
    100% |################################| 212kB 2.6MB/s 
Requirement already satisfied (use --upgrade to upgrade): pyasn1>=0.1.7 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
Collecting pyasn1-modules>=0.0.5 (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
  Downloading pyasn1_modules-0.0.8-py2.py3-none-any.whl
Collecting rsa>=3.1.4 (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
  Downloading rsa-3.4.2-py2.py3-none-any.whl (46kB)
    100% |################################| 49kB 7.7MB/s 
Requirement already satisfied (use --upgrade to upgrade): six>=1.6.1 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
Collecting uncompyle6 (from hypothesis->-r submission-form-scripts/requirements.txt (line 10))
  Downloading uncompyle6-2.8.4-py2.py3-none-any.whl (123kB)
    100% |################################| 126kB 4.0MB/s 
Requirement already satisfied (use --upgrade to upgrade): enum34 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from hypothesis->-r submission-form-scripts/requirements.txt (line 10))
Collecting pyflakes!=1.2.0,!=1.2.1,!=1.2.2,<1.3.0,>=0.8.1 (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading pyflakes-1.2.3-py2.py3-none-any.whl (209kB)
    100% |################################| 212kB 3.3MB/s 
Collecting mccabe<0.6.0,>=0.5.0 (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading mccabe-0.5.2-py2.py3-none-any.whl
Collecting pycodestyle<2.1.0,>=2.0.0 (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading pycodestyle-2.0.0-py2.py3-none-any.whl (42kB)
    100% |################################| 45kB 7.1MB/s 
Collecting configparser (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading configparser-3.5.0.tar.gz
Collecting xdis>=2.3.1 (from uncompyle6->hypothesis->-r submission-form-scripts/requirements.txt (line 10))
  Downloading xdis-2.3.2.tar.gz (80kB)
    100% |################################| 81kB 5.1MB/s 
Collecting spark-parser>=1.4.0 (from uncompyle6->hypothesis->-r submission-form-scripts/requirements.txt (line 10))
  Downloading spark_parser-1.4.0.tar.gz (99kB)
    100% |################################| 102kB 4.6MB/s 
Installing collected packages: spark-parser, xdis, configparser, pycodestyle, mccabe, pyflakes, uncompyle6, rsa, pyasn1-modules, httplib2, flake8, colorama, hypothesis, selenium, pillow, oauth2client, gspread
  Running setup.py install for spark-parser
  Running setup.py install for xdis
    Installing pydisasm script to /home/travis/virtualenv/python2.7.9/bin
  Running setup.py install for configparser
    Skipping installation of /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/backports/__init__.py (namespace package)
    Installing /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/configparser-3.5.0-py2.7-nspkg.pth
  Running setup.py install for httplib2
  Running setup.py install for hypothesis
  Running setup.py install for pillow
    building 'PIL._imaging' extension
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c _imaging.c -o build/temp.linux-x86_64-2.7/_imaging.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c outline.c -o build/temp.linux-x86_64-2.7/outline.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Bands.c -o build/temp.linux-x86_64-2.7/libImaging/Bands.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Convert.c -o build/temp.linux-x86_64-2.7/libImaging/Convert.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c path.c -o build/temp.linux-x86_64-2.7/path.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/BcnDecode.c -o build/temp.linux-x86_64-2.7/libImaging/BcnDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Access.c -o build/temp.linux-x86_64-2.7/libImaging/Access.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/AlphaComposite.c -o build/temp.linux-x86_64-2.7/libImaging/AlphaComposite.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Resample.c -o build/temp.linux-x86_64-2.7/libImaging/Resample.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Dib.c -o build/temp.linux-x86_64-2.7/libImaging/Dib.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Draw.c -o build/temp.linux-x86_64-2.7/libImaging/Draw.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Effects.c -o build/temp.linux-x86_64-2.7/libImaging/Effects.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/EpsEncode.c -o build/temp.linux-x86_64-2.7/libImaging/EpsEncode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/BitDecode.c -o build/temp.linux-x86_64-2.7/libImaging/BitDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c decode.c -o build/temp.linux-x86_64-2.7/decode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/File.c -o build/temp.linux-x86_64-2.7/libImaging/File.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Blend.c -o build/temp.linux-x86_64-2.7/libImaging/Blend.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/ConvertYCbCr.c -o build/temp.linux-x86_64-2.7/libImaging/ConvertYCbCr.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Fill.c -o build/temp.linux-x86_64-2.7/libImaging/Fill.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Chops.c -o build/temp.linux-x86_64-2.7/libImaging/Chops.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/GifDecode.c -o build/temp.linux-x86_64-2.7/libImaging/GifDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c encode.c -o build/temp.linux-x86_64-2.7/encode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Copy.c -o build/temp.linux-x86_64-2.7/libImaging/Copy.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Filter.c -o build/temp.linux-x86_64-2.7/libImaging/Filter.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/GifEncode.c -o build/temp.linux-x86_64-2.7/libImaging/GifEncode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Crc32.c -o build/temp.linux-x86_64-2.7/libImaging/Crc32.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Crop.c -o build/temp.linux-x86_64-2.7/libImaging/Crop.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/JpegEncode.c -o build/temp.linux-x86_64-2.7/libImaging/JpegEncode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/LzwDecode.c -o build/temp.linux-x86_64-2.7/libImaging/LzwDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c map.c -o build/temp.linux-x86_64-2.7/map.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/FliDecode.c -o build/temp.linux-x86_64-2.7/libImaging/FliDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Matrix.c -o build/temp.linux-x86_64-2.7/libImaging/Matrix.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/HexDecode.c -o build/temp.linux-x86_64-2.7/libImaging/HexDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/ModeFilter.c -o build/temp.linux-x86_64-2.7/libImaging/ModeFilter.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c display.c -o build/temp.linux-x86_64-2.7/display.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Geometry.c -o build/temp.linux-x86_64-2.7/libImaging/Geometry.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Histo.c -o build/temp.linux-x86_64-2.7/libImaging/Histo.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/MspDecode.c -o build/temp.linux-x86_64-2.7/libImaging/MspDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Negative.c -o build/temp.linux-x86_64-2.7/libImaging/Negative.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Offset.c -o build/temp.linux-x86_64-2.7/libImaging/Offset.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Pack.c -o build/temp.linux-x86_64-2.7/libImaging/Pack.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Paste.c -o build/temp.linux-x86_64-2.7/libImaging/Paste.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/JpegDecode.c -o build/temp.linux-x86_64-2.7/libImaging/JpegDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/PcdDecode.c -o build/temp.linux-x86_64-2.7/libImaging/PcdDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/PcxDecode.c -o build/temp.linux-x86_64-2.7/libImaging/PcxDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/PackDecode.c -o build/temp.linux-x86_64-2.7/libImaging/PackDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/PcxEncode.c -o build/temp.linux-x86_64-2.7/libImaging/PcxEncode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Palette.c -o build/temp.linux-x86_64-2.7/libImaging/Palette.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/GetBBox.c -o build/temp.linux-x86_64-2.7/libImaging/GetBBox.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Point.c -o build/temp.linux-x86_64-2.7/libImaging/Point.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/RawDecode.c -o build/temp.linux-x86_64-2.7/libImaging/RawDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Quant.c -o build/temp.linux-x86_64-2.7/libImaging/Quant.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/RawEncode.c -o build/temp.linux-x86_64-2.7/libImaging/RawEncode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/RankFilter.c -o build/temp.linux-x86_64-2.7/libImaging/RankFilter.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Unpack.c -o build/temp.linux-x86_64-2.7/libImaging/Unpack.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Storage.c -o build/temp.linux-x86_64-2.7/libImaging/Storage.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/ZipDecode.c -o build/temp.linux-x86_64-2.7/libImaging/ZipDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/SunRleDecode.c -o build/temp.linux-x86_64-2.7/libImaging/SunRleDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/ZipEncode.c -o build/temp.linux-x86_64-2.7/libImaging/ZipEncode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/TgaRleDecode.c -o build/temp.linux-x86_64-2.7/libImaging/TgaRleDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/TiffDecode.c -o build/temp.linux-x86_64-2.7/libImaging/TiffDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Jpeg2KDecode.c -o build/temp.linux-x86_64-2.7/libImaging/Jpeg2KDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/QuantOctree.c -o build/temp.linux-x86_64-2.7/libImaging/QuantOctree.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/Jpeg2KEncode.c -o build/temp.linux-x86_64-2.7/libImaging/Jpeg2KEncode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/BoxBlur.c -o build/temp.linux-x86_64-2.7/libImaging/BoxBlur.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/QuantHash.c -o build/temp.linux-x86_64-2.7/libImaging/QuantHash.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/QuantHeap.c -o build/temp.linux-x86_64-2.7/libImaging/QuantHeap.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/UnpackYCC.c -o build/temp.linux-x86_64-2.7/libImaging/UnpackYCC.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/QuantPngQuant.c -o build/temp.linux-x86_64-2.7/libImaging/QuantPngQuant.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/codec_fd.c -o build/temp.linux-x86_64-2.7/libImaging/codec_fd.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/UnsharpMask.c -o build/temp.linux-x86_64-2.7/libImaging/UnsharpMask.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/XbmDecode.c -o build/temp.linux-x86_64-2.7/libImaging/XbmDecode.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c libImaging/XbmEncode.c -o build/temp.linux-x86_64-2.7/libImaging/XbmEncode.o
    Building using 4 processes
    gcc -pthread -shared -L/opt/python/2.7.9/lib -Wl,-rpath=/opt/python/2.7.9/lib build/temp.linux-x86_64-2.7/_imaging.o build/temp.linux-x86_64-2.7/decode.o build/temp.linux-x86_64-2.7/encode.o build/temp.linux-x86_64-2.7/map.o build/temp.linux-x86_64-2.7/display.o build/temp.linux-x86_64-2.7/outline.o build/temp.linux-x86_64-2.7/path.o build/temp.linux-x86_64-2.7/libImaging/Access.o build/temp.linux-x86_64-2.7/libImaging/AlphaComposite.o build/temp.linux-x86_64-2.7/libImaging/Resample.o build/temp.linux-x86_64-2.7/libImaging/Bands.o build/temp.linux-x86_64-2.7/libImaging/BcnDecode.o build/temp.linux-x86_64-2.7/libImaging/BitDecode.o build/temp.linux-x86_64-2.7/libImaging/Blend.o build/temp.linux-x86_64-2.7/libImaging/Chops.o build/temp.linux-x86_64-2.7/libImaging/Convert.o build/temp.linux-x86_64-2.7/libImaging/ConvertYCbCr.o build/temp.linux-x86_64-2.7/libImaging/Copy.o build/temp.linux-x86_64-2.7/libImaging/Crc32.o build/temp.linux-x86_64-2.7/libImaging/Crop.o build/temp.linux-x86_64-2.7/libImaging/Dib.o build/temp.linux-x86_64-2.7/libImaging/Draw.o build/temp.linux-x86_64-2.7/libImaging/Effects.o build/temp.linux-x86_64-2.7/libImaging/EpsEncode.o build/temp.linux-x86_64-2.7/libImaging/File.o build/temp.linux-x86_64-2.7/libImaging/Fill.o build/temp.linux-x86_64-2.7/libImaging/Filter.o build/temp.linux-x86_64-2.7/libImaging/FliDecode.o build/temp.linux-x86_64-2.7/libImaging/Geometry.o build/temp.linux-x86_64-2.7/libImaging/GetBBox.o build/temp.linux-x86_64-2.7/libImaging/GifDecode.o build/temp.linux-x86_64-2.7/libImaging/GifEncode.o build/temp.linux-x86_64-2.7/libImaging/HexDecode.o build/temp.linux-x86_64-2.7/libImaging/Histo.o build/temp.linux-x86_64-2.7/libImaging/JpegDecode.o build/temp.linux-x86_64-2.7/libImaging/JpegEncode.o build/temp.linux-x86_64-2.7/libImaging/LzwDecode.o build/temp.linux-x86_64-2.7/libImaging/Matrix.o build/temp.linux-x86_64-2.7/libImaging/ModeFilter.o build/temp.linux-x86_64-2.7/libImaging/MspDecode.o build/temp.linux-x86_64-2.7/libImaging/Negative.o build/temp.linux-x86_64-2.7/libImaging/Offset.o build/temp.linux-x86_64-2.7/libImaging/Pack.o build/temp.linux-x86_64-2.7/libImaging/PackDecode.o build/temp.linux-x86_64-2.7/libImaging/Palette.o build/temp.linux-x86_64-2.7/libImaging/Paste.o build/temp.linux-x86_64-2.7/libImaging/Quant.o build/temp.linux-x86_64-2.7/libImaging/QuantOctree.o build/temp.linux-x86_64-2.7/libImaging/QuantHash.o build/temp.linux-x86_64-2.7/libImaging/QuantHeap.o build/temp.linux-x86_64-2.7/libImaging/PcdDecode.o build/temp.linux-x86_64-2.7/libImaging/PcxDecode.o build/temp.linux-x86_64-2.7/libImaging/PcxEncode.o build/temp.linux-x86_64-2.7/libImaging/Point.o build/temp.linux-x86_64-2.7/libImaging/RankFilter.o build/temp.linux-x86_64-2.7/libImaging/RawDecode.o build/temp.linux-x86_64-2.7/libImaging/RawEncode.o build/temp.linux-x86_64-2.7/libImaging/Storage.o build/temp.linux-x86_64-2.7/libImaging/SunRleDecode.o build/temp.linux-x86_64-2.7/libImaging/TgaRleDecode.o build/temp.linux-x86_64-2.7/libImaging/Unpack.o build/temp.linux-x86_64-2.7/libImaging/UnpackYCC.o build/temp.linux-x86_64-2.7/libImaging/UnsharpMask.o build/temp.linux-x86_64-2.7/libImaging/XbmDecode.o build/temp.linux-x86_64-2.7/libImaging/XbmEncode.o build/temp.linux-x86_64-2.7/libImaging/ZipDecode.o build/temp.linux-x86_64-2.7/libImaging/ZipEncode.o build/temp.linux-x86_64-2.7/libImaging/TiffDecode.o build/temp.linux-x86_64-2.7/libImaging/Jpeg2KDecode.o build/temp.linux-x86_64-2.7/libImaging/Jpeg2KEncode.o build/temp.linux-x86_64-2.7/libImaging/BoxBlur.o build/temp.linux-x86_64-2.7/libImaging/QuantPngQuant.o build/temp.linux-x86_64-2.7/libImaging/codec_fd.o -L/home/travis/virtualenv/python2.7.9/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/lib -L/opt/python/2.7.9/lib -L/usr/lib/x86_64-linux-gnu -ljpeg -lz -ltiff -lpython2.7 -o build/lib.linux-x86_64-2.7/PIL/_imaging.so
    building 'PIL._imagingft' extension
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c _imagingft.c -o build/temp.linux-x86_64-2.7/_imagingft.o
    Building using 4 processes
    gcc -pthread -shared -L/opt/python/2.7.9/lib -Wl,-rpath=/opt/python/2.7.9/lib build/temp.linux-x86_64-2.7/_imagingft.o -L/home/travis/virtualenv/python2.7.9/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/lib -L/opt/python/2.7.9/lib -L/usr/lib/x86_64-linux-gnu -lfreetype -lpython2.7 -o build/lib.linux-x86_64-2.7/PIL/_imagingft.so
    building 'PIL._imagingtk' extension
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -ITk -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c _imagingtk.c -o build/temp.linux-x86_64-2.7/_imagingtk.o
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -ITk -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c Tk/tkImaging.c -o build/temp.linux-x86_64-2.7/Tk/tkImaging.o
    Building using 4 processes
    gcc -pthread -shared -L/opt/python/2.7.9/lib -Wl,-rpath=/opt/python/2.7.9/lib build/temp.linux-x86_64-2.7/_imagingtk.o build/temp.linux-x86_64-2.7/Tk/tkImaging.o -L/home/travis/virtualenv/python2.7.9/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/lib -L/opt/python/2.7.9/lib -L/usr/lib/x86_64-linux-gnu -lpython2.7 -o build/lib.linux-x86_64-2.7/PIL/_imagingtk.so
    building 'PIL._imagingmath' extension
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c _imagingmath.c -o build/temp.linux-x86_64-2.7/_imagingmath.o
    Building using 4 processes
    gcc -pthread -shared -L/opt/python/2.7.9/lib -Wl,-rpath=/opt/python/2.7.9/lib build/temp.linux-x86_64-2.7/_imagingmath.o -L/home/travis/virtualenv/python2.7.9/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/lib -L/opt/python/2.7.9/lib -L/usr/lib/x86_64-linux-gnu -lpython2.7 -o build/lib.linux-x86_64-2.7/PIL/_imagingmath.so
    building 'PIL._imagingmorph' extension
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-tXuoad/pillow/libImaging -I/home/travis/virtualenv/python2.7.9/include -I/usr/local/include -I/usr/include -I/opt/python/2.7.9/include/python2.7 -I/usr/include/x86_64-linux-gnu -c _imagingmorph.c -o build/temp.linux-x86_64-2.7/_imagingmorph.o
    Building using 4 processes
    gcc -pthread -shared -L/opt/python/2.7.9/lib -Wl,-rpath=/opt/python/2.7.9/lib build/temp.linux-x86_64-2.7/_imagingmorph.o -L/home/travis/virtualenv/python2.7.9/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/lib -L/opt/python/2.7.9/lib -L/usr/lib/x86_64-linux-gnu -lpython2.7 -o build/lib.linux-x86_64-2.7/PIL/_imagingmorph.so
    --------------------------------------------------------------------
    PIL SETUP SUMMARY
    --------------------------------------------------------------------
    version      Pillow 3.4.1
    platform     linux2 2.7.9 (default, Feb  5 2015, 15:48:42)
                 [GCC 4.6.3]
    --------------------------------------------------------------------
    --- JPEG support available
    *** OPENJPEG (JPEG2000) support not available
    --- ZLIB (PNG/ZIP) support available
    *** LIBIMAGEQUANT support not available
    --- LIBTIFF support available
    --- FREETYPE2 support available
    *** LITTLECMS2 support not available
    *** WEBP support not available
    *** WEBPMUX support not available
    --------------------------------------------------------------------
    To add a missing option, make sure you have the required
    library and headers.
    See https://pillow.readthedocs.io/en/latest/installation.html#building-from-source
    To check the build, run the selftest.py script.
    changing mode of build/scripts-2.7/createfontdatachunk.py from 664 to 775
    changing mode of build/scripts-2.7/pilfile.py from 664 to 775
    changing mode of build/scripts-2.7/explode.py from 664 to 775
    changing mode of build/scripts-2.7/viewer.py from 664 to 775
    changing mode of build/scripts-2.7/thresholder.py from 664 to 775
    changing mode of build/scripts-2.7/player.py from 664 to 775
    changing mode of build/scripts-2.7/gifmaker.py from 664 to 775
    changing mode of build/scripts-2.7/pildriver.py from 664 to 775
    changing mode of build/scripts-2.7/pilconvert.py from 664 to 775
    changing mode of build/scripts-2.7/pilprint.py from 664 to 775
    changing mode of build/scripts-2.7/enhancer.py from 664 to 775
    changing mode of build/scripts-2.7/painter.py from 664 to 775
    changing mode of build/scripts-2.7/pilfont.py from 664 to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/createfontdatachunk.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/pilfile.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/explode.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/viewer.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/thresholder.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/player.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/gifmaker.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/pildriver.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/pilconvert.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/pilprint.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/enhancer.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/painter.py to 775
    changing mode of /home/travis/virtualenv/python2.7.9/bin/pilfont.py to 775
  Running setup.py install for oauth2client
  Running setup.py install for gspread
Successfully installed colorama-0.3.7 configparser-3.5.0 flake8-3.0.4 gspread-0.4.1 httplib2-0.9.2 hypothesis-3.5.3 mccabe-0.5.2 oauth2client-1.5.2 pillow-3.4.1 pyasn1-modules-0.0.8 pycodestyle-2.0.0 pyflakes-1.2.3 rsa-3.4.2 selenium-2.53.6 spark-parser-1.4.0 uncompyle6-2.8.4 xdis-2.3.2
```

https://travis-ci.org/botwiki/botwiki.org/builds/166203040#L509

After, with pip 8.1.2 (7.76s):

```
$ pip install -r submission-form-scripts/requirements.txt
Collecting gspread (from -r submission-form-scripts/requirements.txt (line 2))
  Downloading gspread-0.4.1.tar.gz
Collecting oauth2client==1.5.2 (from -r submission-form-scripts/requirements.txt (line 3))
  Downloading oauth2client-1.5.2.tar.gz (56kB)
    100% |████████████████████████████████| 61kB 4.6MB/s 
Collecting pillow>=2.9.0 (from -r submission-form-scripts/requirements.txt (line 6))
  Downloading Pillow-3.4.1-cp27-cp27mu-manylinux1_x86_64.whl (5.6MB)
    100% |████████████████████████████████| 5.6MB 255kB/s 
Collecting selenium (from -r submission-form-scripts/requirements.txt (line 7))
  Downloading selenium-2.53.6-py2.py3-none-any.whl (884kB)
    100% |████████████████████████████████| 890kB 1.7MB/s 
Collecting hypothesis (from -r submission-form-scripts/requirements.txt (line 10))
  Downloading hypothesis-3.5.3.tar.gz (73kB)
    100% |████████████████████████████████| 81kB 11.5MB/s 
Collecting colorama (from -r submission-form-scripts/requirements.txt (line 13))
  Downloading colorama-0.3.7-py2.py3-none-any.whl
Collecting flake8 (from -r submission-form-scripts/requirements.txt (line 14))
  Downloading flake8-3.0.4-py2.py3-none-any.whl (64kB)
    100% |████████████████████████████████| 71kB 8.6MB/s 
Requirement already satisfied (use --upgrade to upgrade): requests>=2.2.1 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from gspread->-r submission-form-scripts/requirements.txt (line 2))
Collecting httplib2>=0.9.1 (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
  Downloading httplib2-0.9.2.zip (210kB)
    100% |████████████████████████████████| 215kB 5.0MB/s 
Requirement already satisfied (use --upgrade to upgrade): pyasn1>=0.1.7 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
Collecting pyasn1-modules>=0.0.5 (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
  Downloading pyasn1_modules-0.0.8-py2.py3-none-any.whl
Collecting rsa>=3.1.4 (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
  Downloading rsa-3.4.2-py2.py3-none-any.whl (46kB)
    100% |████████████████████████████████| 51kB 9.6MB/s 
Requirement already satisfied (use --upgrade to upgrade): six>=1.6.1 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from oauth2client==1.5.2->-r submission-form-scripts/requirements.txt (line 3))
Collecting uncompyle6 (from hypothesis->-r submission-form-scripts/requirements.txt (line 10))
  Downloading uncompyle6-2.8.4-py2.py3-none-any.whl (123kB)
    100% |████████████████████████████████| 133kB 9.5MB/s 
Requirement already satisfied (use --upgrade to upgrade): enum34 in /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages (from hypothesis->-r submission-form-scripts/requirements.txt (line 10))
Collecting configparser; python_version < "3.2" (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading configparser-3.5.0.tar.gz
Collecting mccabe<0.6.0,>=0.5.0 (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading mccabe-0.5.2-py2.py3-none-any.whl
Collecting pycodestyle<2.1.0,>=2.0.0 (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading pycodestyle-2.0.0-py2.py3-none-any.whl (42kB)
    100% |████████████████████████████████| 51kB 11.4MB/s 
Collecting pyflakes!=1.2.0,!=1.2.1,!=1.2.2,<1.3.0,>=0.8.1 (from flake8->-r submission-form-scripts/requirements.txt (line 14))
  Downloading pyflakes-1.2.3-py2.py3-none-any.whl (209kB)
    100% |████████████████████████████████| 215kB 7.5MB/s 
Collecting xdis>=2.3.1 (from uncompyle6->hypothesis->-r submission-form-scripts/requirements.txt (line 10))
  Downloading xdis-2.3.2.tar.gz (80kB)
    100% |████████████████████████████████| 81kB 8.3MB/s 
Collecting spark-parser>=1.4.0 (from uncompyle6->hypothesis->-r submission-form-scripts/requirements.txt (line 10))
  Downloading spark_parser-1.4.0.tar.gz (99kB)
    100% |████████████████████████████████| 102kB 8.2MB/s 
Building wheels for collected packages: gspread, oauth2client, hypothesis, httplib2, configparser, xdis, spark-parser
  Running setup.py bdist_wheel for gspread ... -done
  Stored in directory: /home/travis/.cache/pip/wheels/8f/98/50/b10b6876e483354bbb369dc5648538ed5bda8d028dc64f13a5
  Running setup.py bdist_wheel for oauth2client ... done
  Stored in directory: /home/travis/.cache/pip/wheels/8b/d3/ab/4f2cde852644a0a08c70a5697ed7f0e27ae44a646d9be79a61
  Running setup.py bdist_wheel for hypothesis ... -done
  Stored in directory: /home/travis/.cache/pip/wheels/b4/37/2a/c3abb3a6b2768dcef6114c7cb88b8c88ede5eff2e51d8ae445
  Running setup.py bdist_wheel for httplib2 ... done
  Stored in directory: /home/travis/.cache/pip/wheels/c7/67/60/e0be8ccfc1e08f8ff1f50d99ea5378e204580ea77b0169fb55
  Running setup.py bdist_wheel for configparser ... done
  Stored in directory: /home/travis/.cache/pip/wheels/1c/bd/b4/277af3f6c40645661b4cd1c21df26aca0f2e1e9714a1d4cda8
  Running setup.py bdist_wheel for xdis ... -done
  Stored in directory: /home/travis/.cache/pip/wheels/7e/93/9d/49398b47493aa79b3d3bc38f2bcd88d7cecae4d19bebdf6bea
  Running setup.py bdist_wheel for spark-parser ... done
  Stored in directory: /home/travis/.cache/pip/wheels/e1/94/8a/7862cdb72f0c44f8f62ed8e41892951cc22a8a7a912ea94d8d
Successfully built gspread oauth2client hypothesis httplib2 configparser xdis spark-parser
Installing collected packages: gspread, httplib2, pyasn1-modules, rsa, oauth2client, pillow, selenium, xdis, spark-parser, uncompyle6, hypothesis, colorama, configparser, mccabe, pycodestyle, pyflakes, flake8
Successfully installed colorama-0.3.7 configparser-3.5.0 flake8-3.0.4 gspread-0.4.1 httplib2-0.9.2 hypothesis-3.5.3 mccabe-0.5.2 oauth2client-1.5.2 pillow-3.4.1 pyasn1-modules-0.0.8 pycodestyle-2.0.0 pyflakes-1.2.3 rsa-3.4.2 selenium-2.53.6 spark-parser-1.4.0 uncompyle6-2.8.4 xdis-2.3.2
```

https://travis-ci.org/hugovk/botwiki.org/builds/166223658#L374
