### PR TITLE
CI: check links in markdown

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# Top-most EditorConfig file
+root = true
+
+[*]
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Two-space indentation
+indent_size = 2
+indent_style = space
+
+[*.py]
+# Four-space indentation
+indent_size = 4
+indent_style = space
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
+# Use the Trusty beta, contains updated Node in Python images
+# https://docs.travis-ci.com/user/trusty-ci-environment#Using-the-Trusty-beta
+sudo: required
+dist: trusty
+
 language: python
 
 python:
   - 2.7
-
-# Use container-based infrastructure
-sudo: false
 
 env:
   - DISABLE_NOTIFIER=true
@@ -17,6 +19,7 @@ install:
   - npm install gulp --global
   - npm install gulp --save-dev
   - npm install
+  - npm install -g markdown-link-check
 
   - pip install -U "pip>=1.5.6"
   - pip install "pycrypto>=2.6"
@@ -33,3 +36,7 @@ script:
   - python submission-form-scripts/test_botsheeter.py
   # Error and style-checker
   - flake8 submission-form-scripts/*.py
+
+  # Cat all the .md files into a single, big file and then check links
+  - find content/ -name '*.md' -exec cat {} \; > /tmp/all-the-markdown.md
+  - markdown-link-check /tmp/all-the-markdown.md

--- a/content/about/press.md
+++ b/content/about/press.md
@@ -21,7 +21,7 @@ Below is a list of articles that talk about Botwiki and related projects, or tha
 
 > Developed by BotWiki, The Monthly Bot Challenge started as a community event with a simple concept: on the first day of each month, a new challenge topic – and prize – is announced online. 
 
-- [BotWiki / Monthly Bot Challenge](http://www.andfestival.org.uk/events/botwiki-monthly-bot-challenge/) -- March 2016, *[andfestival.org](http://andfestival.org/)*
+- [BotWiki / Monthly Bot Challenge](http://www.andfestival.org.uk/events/botwiki-monthly-bot-challenge/) -- March 2016, *[andfestival.org.uk](http://andfestival.org.uk/)*
 
 
 > Le site botwiki.org a commencé à les cataloguer, en plus d’offrir des tutoriaux pour en créer et plein d’informations, et comme Twitter est un des réseaux les plus accueillants je vous ai fait une petite sélection de mes préférés :

--- a/content/bots/aim-bots/GooglyMinotaur.md
+++ b/content/bots/aim-bots/GooglyMinotaur.md
@@ -10,7 +10,7 @@ Nav: hidden
 Robots: index,follow
 */
 
-[GooglyMinotaur](https://en.wikipedia.org/wiki/GooglyMinotaur) is an AOL Instant Messenger bot created by [ActiveBuddy](https://twitter.com/http://timkay.com/activebuddy/). 
+[GooglyMinotaur](https://en.wikipedia.org/wiki/GooglyMinotaur) is an AOL Instant Messenger bot created by [ActiveBuddy](http://timkay.com/activebuddy/).
 
 From [Wikipedia](https://en.wikipedia.org/wiki/GooglyMinotaur):
 

--- a/content/bots/facebook-messenger-bots/CalcBot.md
+++ b/content/bots/facebook-messenger-bots/CalcBot.md
@@ -9,6 +9,6 @@ Nav: hidden
 Robots: index,follow
 */
 
-[CalcBot](http://m.me/CalcBot) is a Facebook Messenger bot created by [GifHip Labs](https://twitter.com/http://www.gifhip.com) that does "all sorts of calculations" 
+[CalcBot](http://m.me/CalcBot) is a Facebook Messenger bot created by [GifHip Labs](http://www.gifhip.com) that does "all sorts of calculations"
 
 > Math (*5+5*2*), conversions (*convert 5cm to inches*) and even calculate your tip (*tip $45*).

--- a/content/bots/twitterbots/almostamends.md
+++ b/content/bots/twitterbots/almostamends.md
@@ -10,6 +10,6 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@almostamends](https://twitter.com/almostamends) is an [open source](https://github.com/inkleby/inklebyrobots/blob/master/robots/amendments.py) Twitter bot created by [Alex Parsons](https://twitter.com/http://www.twitter.com/alexparsons). 
+[@almostamends](https://twitter.com/almostamends) is an [open source](https://github.com/inkleby/inklebyrobots/blob/master/robots/amendments.py) Twitter bot created by [Alex Parsons](https://twitter.com/alexparsons).
 
 Almost Amends is a historical dataset tweeter - using the data from the US National Archive's [Amending America](https://www.archives.gov/amending-america/) collection to tweet random attempted amendments to the US Constitution (from a set of 11,000) - adding links to more information where available.

--- a/content/bots/twitterbots/bayareabotarts.md
+++ b/content/bots/twitterbots/bayareabotarts.md
@@ -10,4 +10,4 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@bayareabotarts](https://www.twitter.com/bayareabotarts) is a Twitter bot created by [Kasey Robinson](https://twitter.com/www.twitter.com/bitpixi) that tweets the picture of the day from NASA, on top of updates for the [Bay Area Bot Arts Meetup group](http://www.meetup.com/Bay-Area-Bot-Arts/).
+[@bayareabotarts](https://www.twitter.com/bayareabotarts) is a Twitter bot created by [Kasey Robinson](https://twitter.com/bitpixi) that tweets the picture of the day from NASA, on top of updates for the [Bay Area Bot Arts Meetup group](http://www.meetup.com/Bay-Area-Bot-Arts/).

--- a/content/bots/twitterbots/cdarwin.md
+++ b/content/bots/twitterbots/cdarwin.md
@@ -10,7 +10,7 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@cdarwin](https://twitter.com/cdarwin) is a Twitter bot created by [David Jones](https://twitter.com/http://www.metaburbia.com/). 
+[@cdarwin](https://twitter.com/cdarwin) is a Twitter bot created by [David Jones](http://www.metaburbia.com/).
 
 > In December 1831 the 22 year old [Charles Darwin](https://en.wikipedia.org/wiki/Charles_Darwin) set sail on a five-year voyage around the world in a survey ship named [The Beagle](https://en.wikipedia.org/wiki/HMS_Beagle). He kept a diary...
 

--- a/content/bots/twitterbots/culturereusebot.md
+++ b/content/bots/twitterbots/culturereusebot.md
@@ -10,6 +10,6 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@culturereusebot](https://twitter.com/culturereusebot) is an [open source](https://github.com/inkleby/inklebyrobots) Twitter bot created by [Alex Parsons](https://twitter.com/http://www.twitter.com/alexparsons). 
+[@culturereusebot](https://twitter.com/culturereusebot) is an [open source](https://github.com/inkleby/inklebyrobots) Twitter bot created by [Alex Parsons](https://twitter.com/alexparsons).
 
 It downloads public domain films from [archive.org](https://archive.org/), looks for short, interesting bits and shares them on Twitter and [Tumblr](http://www.inkleby.com/blog/2016/03/culture-reuse-bot/).

--- a/content/bots/twitterbots/everytwitpic.md
+++ b/content/bots/twitterbots/everytwitpic.md
@@ -10,5 +10,5 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@everytwitpic](https://twitter.com/everytwitpic) is an [open source](https://github.com/NiciusB/everytwitpic) Twitter bot created by [Nuno Balbona](https://twitter.com/https://github.com/NiciusB) that posts every word in the Spanish language in the form of a [Twitpic](http://twitpic.com/) link. (The links don't always point to existing images.)
+[@everytwitpic](https://twitter.com/everytwitpic) is an [open source](https://github.com/NiciusB/everytwitpic) Twitter bot created by [Nuno Balbona](https://github.com/NiciusB) that posts every word in the Spanish language in the form of a [Twitpic](http://twitpic.com/) link. (The links don't always point to existing images.)
 

--- a/content/bots/twitterbots/invandringgarna.md
+++ b/content/bots/twitterbots/invandringgarna.md
@@ -10,7 +10,7 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@invandringgarna](http://twitter.com/invandringgarna) is an [open source](https://github.com/ArVID220u/invandringsbot) Twitter bot created by [ArVID220u](https://twitter.com/http://twitter.com/arvid220u). 
+[@invandringgarna](http://twitter.com/invandringgarna) is an [open source](https://github.com/ArVID220u/invandringsbot) Twitter bot created by [ArVID220u](https://twitter.com/arvid220u).
 
 When people post ignorant tweets about immigration, this bot replies with a rant about the moral responsibility we all have to welcome refugees.
 

--- a/content/bots/twitterbots/licensemee.md
+++ b/content/bots/twitterbots/licensemee.md
@@ -10,4 +10,4 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@licensemee](https://twitter.com/licensemee) is a Twitter bot created by [Audrey Eschright](https://twitter.com/http://lifeofaudrey.com/) that generates "creative licenses".
+[@licensemee](https://twitter.com/licensemee) is a Twitter bot created by [Audrey Eschright](http://lifeofaudrey.com/) that generates "creative licenses".

--- a/content/bots/twitterbots/space_stories.md
+++ b/content/bots/twitterbots/space_stories.md
@@ -10,6 +10,6 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@space_stories](http://twitter.com/space_stories) is a Twitter bot created by [@notinventedhere](https://twitter.com/http://twitter.com/notinventedhere) that generates short stories about things happening in space.
+[@space_stories](http://twitter.com/space_stories) is a Twitter bot created by [@notinventedhere](https://twitter.com/notinventedhere) that generates short stories about things happening in space.
 
 It was made in collaboration with [Thom](http://twitter.com/thos_thom) of [TACS Games](http://tacsgames.com/).

--- a/content/bots/twitterbots/thementrends.md
+++ b/content/bots/twitterbots/thementrends.md
@@ -10,6 +10,6 @@ Nav: hidden
 Robots: index,follow
 */
 
-[@thementrends](http://www.twitter.com/thementrends) is a Twitter bot created by [Martin](https://twitter.com/http://www.twitter.com/ryc_m) that tweets the most read articles on German language Wikipedia.
+[@thementrends](http://www.twitter.com/thementrends) is a Twitter bot created by [Martin](http://www.twitter.com/ryc_m) that tweets the most read articles on German language Wikipedia.
 
-Detailed hourly updated page view statistics for German and other languages are available on [trending.eu](http://www.trending.eu). 
+Detailed hourly updated page view statistics for German and other languages are available on [trending.eu](http://www.trending.eu).


### PR DESCRIPTION
We can use [markdown-link-check](https://github.com/tcort/markdown-link-check) to check all of the hyperlinks in markdown to determine if they are alive or dead.

For example: https://travis-ci.org/hugovk/botwiki.org/builds/169704157#L602

I also fixed some broken links it found, and added [EditorConfig](http://editorconfig.org/#download) to help maintain standards.

markdown-link-check takes about 3.5 minutes on the CI, which is probably ok. If you prefer, or if it ever starts timing out the CI (> 10 mins), I could change it to only check the files that have changed between master and the current branch.
