### PR TITLE
Remove unittest2, only needed by unsupported Python 2.6

### DIFF
--- a/submission-form-scripts/test_botsheeter.py
+++ b/submission-form-scripts/test_botsheeter.py
@@ -6,10 +6,7 @@ Unit tests for botsheeter.py
 from __future__ import print_function, unicode_literals
 from hypothesis import given
 from hypothesis.strategies import text
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import botsheeter
 


### PR DESCRIPTION
We're only running on Python 2.7, no need to support the really old Python 2.6.

https://en.wikipedia.org/wiki/CPython#Version_history